### PR TITLE
Add time-averaged joule heating auxkernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HIVE: Heating by Induction to Verify Extremes
 
-_Nuno Nobre and Karthikeyan Chockalingam_
+_Nuno Nobre, Josh Williams and Karthikeyan Chockalingam_
 
 ###
 
@@ -82,11 +82,12 @@ coupling pipeline proceeds as follows:
 
     Solved for the magnetic vector potential $\mathbf{A} \in \mathcal{N}^0_I$
     [<sup>(*)</sup>](https://defelement.com/elements/examples/tetrahedron-nedelec1-lagrange-0.html),
-    everywhere in space and for each time step, with Dirichlet boundary
-    conditions on the $\mathbf{n}$-oriented plane boundary of the vacuum
-    chamber where the coil terminals sit, $\mathbf{A} × \mathbf{n} = 0$, and
-    Neumann boundary conditions on its remaining $\mathbf{n}$-oriented outer
-    surfaces, $\mathbf{∇} × \mathbf{A} × \mathbf{n} = 0$.
+    everywhere in space and for each time step $\Delta t_\mathrm{AF}$ of only a
+    reduced selection of cycles of the voltage source in (1), with Dirichlet
+    boundary conditions on the $\mathbf{n}$-oriented plane boundary of the
+    vacuum chamber where the coil terminals sit, $\mathbf{A} × \mathbf{n} = 0$,
+    and Neumann boundary conditions on its remaining $\mathbf{n}$-oriented
+    outer surfaces, $\mathbf{∇} × \mathbf{A} × \mathbf{n} = 0$.
     $ν$ is the magnetic reluctivity (the reciprocal of the magnetic
     permeability) and $σ$ is the electrical conductivity.
     The right-hand side is non-zero only within the coil, see (1), and is
@@ -97,14 +98,17 @@ coupling pipeline proceeds as follows:
 
    Solved for the temperature $T \in \mathcal{P}^1$
    [<sup>(*)</sup>](https://defelement.com/elements/examples/tetrahedron-lagrange-equispaced-1.html),
-   everywhere in space and for each time step, with Neumann boundary conditions
-   on the $\mathbf{n}$-oriented outer surface of the vacuum chamber,
-   $\mathbf{∇}T \cdot \mathbf{n} = 0$, and initial conditions everywhere in
-   space, $T = T_\mathrm{room}$.
+   everywhere in space and for each time step $\Delta t_\mathrm{TH}$, with
+   Neumann boundary conditions on the $\mathbf{n}$-oriented outer surface of
+   the vacuum chamber, $\mathbf{∇}T \cdot \mathbf{n} = 0$, and initial
+   conditions everywhere in space, $T = T_\mathrm{room}$.
    $ρ$ is the density, $c$ is the specific heat capacity, and $k$ is the
    thermal conductivity.
-   The right-hand side is the Joule heating term which, as of this writing, we
-   compute only on the target.
+   The right-hand side is the Joule heating term which we compute only on the
+   target and is time-averaged over the simulated time interval in (2). This
+   enables quicker simulations by solving for the temperature $T$ on a larger
+   time scale than the magnetic vector potential $\mathbf{A}$, i.e.
+   $\Delta t_\mathrm{TH} >> \Delta t_\mathrm{AF}$.
 
 See [input/Parameters.i](input/Parameters.i) for the set of parameters
 influencing the simulation.
@@ -133,11 +137,6 @@ accuracy, time-to-solution and general usability.
 * Add support to MOOSE (+libMesh) for $\mathcal{N}^1_I$ variables on TET14s.
 
 ### Time-to-solution
-
-* Switch to a time-averaged Joule heating source in the heat equation sub-app
-  to keep the problem tractable when simulating over a long physical time span.
-  The $\mathbf{A}$ formulation sub-app will then sub-cycle, i.e. perform
-  multiple time steps for each time step of the heat equation sub-app.
 
 * Study the potential gains of solving all, but most importantly the
   $\mathbf{A}$ formulation sub-app, on the GPU simply via PETSc/hypre flags.

--- a/include/auxkernels/JouleHeatingAux.h
+++ b/include/auxkernels/JouleHeatingAux.h
@@ -16,5 +16,11 @@ protected:
   const VectorVariableValue & _electric_field;
 
   /// The electrical conductivity
-  Real _sigma;
+  const Real _sigma;
+
+  /// Time interval after which the kernel starts computing
+  const Real _skip;
+
+  /// Whether to take the time average
+  const bool _avg;
 };

--- a/input/AForm.i
+++ b/input/AForm.i
@@ -79,6 +79,7 @@
     variable = P
     vector_potential = A
     sigma = ${steel_econductivity}
+    skip = ${fparse end_t_af/2}
     block = target
     execute_on = timestep_end
   []
@@ -124,7 +125,9 @@
   solve_type = LINEAR
   petsc_options_iname = -pc_type
   petsc_options_value = cholesky
-  num_steps = 1
+  start_time = 0.0
+  end_time = ${end_t_af}
+  dt = ${delta_t_af}
 []
 
 [Outputs]

--- a/input/AForm.i
+++ b/input/AForm.i
@@ -79,7 +79,7 @@
     variable = P
     vector_potential = A
     sigma = ${steel_econductivity}
-    skip = ${fparse end_t_af/2}
+    skip = ${skip_t_af}
     block = target
     execute_on = timestep_end
   []

--- a/input/Parameters.i
+++ b/input/Parameters.i
@@ -26,7 +26,9 @@ voltage_frequency    = 1e5                                    # Hz
 voltage_wfrequency   = ${fparse 2*pi*voltage_frequency}       # rad/s
 voltage_period       = ${fparse 1/voltage_frequency}          # s
 
-end_t                = ${fparse voltage_period}               # s
-delta_t              = ${fparse voltage_period/10}            # s
+end_t_af             = ${fparse voltage_period*10}            # s
+end_t_th             = 60                                     # s
+delta_t_af           = ${fparse voltage_period/10}            # s
+delta_t_th           = 5                                      # s
 
 visualization        = false

--- a/input/Parameters.i
+++ b/input/Parameters.i
@@ -26,9 +26,11 @@ voltage_frequency    = 1e5                                    # Hz
 voltage_wfrequency   = ${fparse 2*pi*voltage_frequency}       # rad/s
 voltage_period       = ${fparse 1/voltage_frequency}          # s
 
-end_t_af             = ${fparse voltage_period*10}            # s
-end_t_th             = 60                                     # s
-delta_t_af           = ${fparse voltage_period/10}            # s
+delta_t_af           = ${fparse voltage_period/50}            # s
+skip_t_af            = ${fparse voltage_period}               # s
+end_t_af             = ${fparse voltage_period*2}             # s
+
 delta_t_th           = 5                                      # s
+end_t_th             = 60                                     # s
 
 visualization        = false

--- a/input/THeat.i
+++ b/input/THeat.i
@@ -92,8 +92,8 @@
   petsc_options_iname = '-pc_type -ksp_rtol'
   petsc_options_value = 'hypre    1e-12'
   start_time = 0.0
-  end_time = ${end_t}
-  dt = ${delta_t}
+  end_time = ${end_t_th}
+  dt = ${delta_t_th}
 []
 
 [Outputs]
@@ -103,9 +103,9 @@
 
 [MultiApps]
   [AForm]
-    type = TransientMultiApp
+    type = FullSolveMultiApp
     input_files = AForm.i
-    execute_on = timestep_begin
+    execute_on = initial
     clone_parent_mesh = true
   []
 []

--- a/src/auxkernels/JouleHeatingAux.C
+++ b/src/auxkernels/JouleHeatingAux.C
@@ -6,22 +6,31 @@ InputParameters
 JouleHeatingAux::validParams()
 {
   InputParameters params = AuxKernel::validParams();
-  params.addClassDescription(
-      "Computes the differential form of the Joule heating equation (power per unit volume).");
+  params.addClassDescription("Computes (optionally, the time average of) the differential form of "
+                             "the Joule heating equation (power per unit volume). "
+                             "The user may specify a time interval only after which the kernel "
+                             "starts computing. If computing the time average, the right endpoint "
+                             "rectangle rule is used for integration.");
   params.addCoupledVar("vector_potential", "The vector potential variable");
   params.addParam<Real>("sigma", 1, "The electrical conductivity");
+  params.addParam<Real>("skip", 0, "Time interval after which the kernel starts computing");
+  params.addParam<bool>("average", true, "Whether to take the time average");
   return params;
 }
 
 JouleHeatingAux::JouleHeatingAux(const InputParameters & parameters)
   : AuxKernel(parameters),
     _electric_field(coupledVectorDot("vector_potential")),
-    _sigma(getParam<Real>("sigma"))
+    _sigma(getParam<Real>("sigma")),
+    _skip(getParam<Real>("skip")),
+    _avg(getParam<bool>("average"))
 {
 }
 
 Real
 JouleHeatingAux::computeValue()
 {
-  return _sigma * _electric_field[_qp] * _electric_field[_qp];
+  Real p = _sigma * _electric_field[_qp] * _electric_field[_qp];
+  Real w = _t > _skip ? _avg ? _dt / (_t - _skip) : 1 : 0;
+  return (1 - w) * _u[_qp] + w * p;
 }


### PR DESCRIPTION
I added code for time-averaged joule heating, and made modifications to the example.

The figure below shows some test results, with `end_t_temp = ${fparse voltage_period*20}` and varying `delta_t_temp`. The compute time results are below:
- Black line: 838 s
- Blue dots: 616 s
- Green dots: 75 s

![pr_fig](https://github.com/user-attachments/assets/c2bd6a5c-6fa3-4885-862b-71cad619d254)
