### PR TITLE
Add MaterialProperty to relevant kernels and auxkernels

### DIFF
--- a/include/auxkernels/JouleHeatingAux.h
+++ b/include/auxkernels/JouleHeatingAux.h
@@ -16,7 +16,7 @@ protected:
   const VectorVariableValue & _electric_field;
 
   /// The electrical conductivity
-  const Real _sigma;
+  const MaterialProperty<Real> & _sigma;
 
   /// Time interval after which the kernel starts computing
   const Real _skip;

--- a/include/kernels/MatCoupledGrad.h
+++ b/include/kernels/MatCoupledGrad.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "VectorKernel.h"
+
+/**
+ *  Weak form contribution corresponding to -f*grad(p)
+ */
+class MatCoupledGrad : public VectorKernel
+{
+public:
+  static InputParameters validParams();
+
+  MatCoupledGrad(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
+
+  /// coupled scalar variable
+  MooseVariable & _p_var;
+  unsigned int _p_var_num;
+
+  const VariableGradient & _grad_p;
+  const VariablePhiGradient & _grad_phi;
+
+  /// Optional function value
+  const Function & _function;
+
+  /// The material the field is multiplied with
+  const MaterialProperty<Real> & _material;
+};

--- a/include/kernels/MatCurlCurlField.h
+++ b/include/kernels/MatCurlCurlField.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CurlCurlField.h"
+
+/**
+ * Curl-curl field multiplied by a material
+ */
+class MatCurlCurlField : public CurlCurlField
+{
+public:
+  static InputParameters validParams();
+
+  MatCurlCurlField(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  /// The material the field is multiplied with
+  const MaterialProperty<Real> & _coeff;
+};

--- a/include/kernels/MatVectorTimeDerivative.h
+++ b/include/kernels/MatVectorTimeDerivative.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "VectorTimeDerivative.h"
+
+/**
+ * Time derivative term multiplied by a material
+ */
+class MatVectorTimeDerivative : public VectorTimeDerivative
+{
+public:
+  static InputParameters validParams();
+
+  MatVectorTimeDerivative(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+
+  // The material the time derivative is multiplied with
+  const MaterialProperty<Real> & _coeff;
+};

--- a/input/AForm.i
+++ b/input/AForm.i
@@ -80,9 +80,8 @@
 
 [Functions]
   [ss316l-sigma-func]
-    type = PiecewiseLinear
-    data_file = ../matprops/steel_316L_electrical_conductivity.csv
-    format = columns
+    type = ConstantFunction
+    value = ${steel_econductivity}
   []
 []
 

--- a/input/AForm.i
+++ b/input/AForm.i
@@ -11,6 +11,11 @@
 []
 
 [AuxVariables]
+  [T]
+    family = LAGRANGE
+    order = FIRST
+    initial_condition = ${room_temperature}
+  []
   [V]
     family = LAGRANGE
     order = FIRST
@@ -53,9 +58,9 @@
     block = vacuum_region
   []
   [dAdt_target]
-    type = CoefVectorTimeDerivative
+    type = MatVectorTimeDerivative
     variable = A
-    coeff = ${steel_econductivity}
+    material = "electric_conductivity"
     block = target
   []
   [dAdt_coil_vacuum]
@@ -73,12 +78,42 @@
   []
 []
 
+[Functions]
+  [ss316l-sigma-func]
+    type = PiecewiseLinear
+    data_file = ../matprops/steel_316L_electrical_conductivity.csv
+    format = columns
+  []
+[]
+
+
+[Materials]
+  [steel-sigma]
+    type = CoupledValueFunctionMaterial
+    v = T
+    prop_name = "electric_conductivity"
+    function = ss316l-sigma-func
+    block = "target"
+  []
+  [copper]
+    type = GenericConstantMaterial
+    prop_names =  'electric_conductivity'
+    prop_values = '${copper_econductivity}'
+    block = 'coil'
+  []
+  [vacuum]
+    type = GenericConstantMaterial
+    prop_names =  'electric_conductivity'
+    prop_values = '${vacuum_econductivity}'
+    block = 'vacuum_region'
+  []
+[]
+
 [AuxKernels]
   [P]
     type = JouleHeatingAux
     variable = P
     vector_potential = A
-    sigma = ${steel_econductivity}
     skip = ${skip_t_af}
     block = target
     execute_on = timestep_end

--- a/src/auxkernels/JouleHeatingAux.C
+++ b/src/auxkernels/JouleHeatingAux.C
@@ -12,7 +12,6 @@ JouleHeatingAux::validParams()
                              "starts computing. If computing the time average, the right endpoint "
                              "rectangle rule is used for integration.");
   params.addCoupledVar("vector_potential", "The vector potential variable");
-  params.addParam<Real>("sigma", 1, "The electrical conductivity");
   params.addParam<Real>("skip", 0, "Time interval after which the kernel starts computing");
   params.addParam<bool>("average", true, "Whether to take the time average");
   return params;
@@ -21,7 +20,7 @@ JouleHeatingAux::validParams()
 JouleHeatingAux::JouleHeatingAux(const InputParameters & parameters)
   : AuxKernel(parameters),
     _electric_field(coupledVectorDot("vector_potential")),
-    _sigma(getParam<Real>("sigma")),
+    _sigma(getMaterialProperty<Real>("electric_conductivity")),
     _skip(getParam<Real>("skip")),
     _avg(getParam<bool>("average"))
 {
@@ -30,7 +29,7 @@ JouleHeatingAux::JouleHeatingAux(const InputParameters & parameters)
 Real
 JouleHeatingAux::computeValue()
 {
-  Real p = _sigma * _electric_field[_qp] * _electric_field[_qp];
+  Real p = (_sigma)[_qp] * _electric_field[_qp] * _electric_field[_qp];
   Real w = _t > _skip ? _avg ? _dt / (_t - _skip) : 1 : 0;
   return (1 - w) * _u[_qp] + w * p;
 }

--- a/src/kernels/MatCoupledGrad.C
+++ b/src/kernels/MatCoupledGrad.C
@@ -1,0 +1,45 @@
+#include "MatCoupledGrad.h"
+#include "Function.h"
+#include "Assembly.h"
+
+registerMooseObject("hiveApp", MatCoupledGrad);
+
+InputParameters
+MatCoupledGrad::validParams()
+{
+  InputParameters params = VectorKernel::validParams();
+  params.addClassDescription("Takes the gradient of a scalar field, optionally "
+                             "scaled by a constant scalar coefficient.");
+  params.addRequiredCoupledVar("coupled_scalar_variable", "The scalar field");
+  params.addRequiredParam<MaterialPropertyName>(
+      "material",
+      "The name of the material property that will be multiplied by the function.");
+  params.addParam<FunctionName>("function", "1", "A scalar function to scale the potential by");
+  return params;
+}
+
+MatCoupledGrad::MatCoupledGrad(const InputParameters & parameters)
+  : VectorKernel(parameters),
+    _p_var(*getVar("coupled_scalar_variable", 0)),
+    _p_var_num(coupled("coupled_scalar_variable")),
+    _grad_p(coupledGradient("coupled_scalar_variable")),
+    _grad_phi(_assembly.gradPhi(_p_var)),
+    _function(getFunction("function")),
+    _material(getMaterialProperty<Real>("material"))
+{
+}
+
+Real
+MatCoupledGrad::computeQpResidual()
+{
+  return _material[_qp] * _function.value(_t, _q_point[_qp]) * _grad_p[_qp] * _test[_i][_qp];
+}
+
+Real
+MatCoupledGrad::computeQpOffDiagJacobian(unsigned jvar)
+{
+  if (_p_var_num == jvar)
+    return _material[_qp] * _function.value(_t, _q_point[_qp]) * _grad_phi[_j][_qp] * _test[_i][_qp];
+
+  return 0.0;
+}

--- a/src/kernels/MatCurlCurlField.C
+++ b/src/kernels/MatCurlCurlField.C
@@ -1,0 +1,30 @@
+#include "MatCurlCurlField.h"
+
+registerMooseObject("MooseApp", MatCurlCurlField);
+
+InputParameters
+MatCurlCurlField::validParams()
+{
+  InputParameters params = CurlCurlField::validParams();
+  params.addRequiredParam<MaterialPropertyName>(
+      "material",
+      "The name of the material property that will be multiplied by the curl-curl field.");
+  return params;
+}
+
+MatCurlCurlField::MatCurlCurlField(const InputParameters & parameters)
+  : CurlCurlField(parameters), _coeff(getMaterialProperty<Real>("material"))
+{
+}
+
+Real
+MatCurlCurlField::computeQpResidual()
+{
+  return _coeff[_qp] * CurlCurlField::computeQpResidual();
+}
+
+Real
+MatCurlCurlField::computeQpJacobian()
+{
+  return _coeff[_qp] * CurlCurlField::computeQpJacobian();
+}

--- a/src/kernels/MatVectorTimeDerivative.C
+++ b/src/kernels/MatVectorTimeDerivative.C
@@ -1,0 +1,30 @@
+#include "MatVectorTimeDerivative.h"
+
+registerMooseObject("MooseApp", MatVectorTimeDerivative);
+
+InputParameters
+MatVectorTimeDerivative::validParams()
+{
+  InputParameters params = VectorTimeDerivative::validParams();
+  params.addRequiredParam<MaterialPropertyName>(
+      "material",
+      "The name of the material property that will be multiplied by the vector time derivative.");
+  return params;
+}
+
+MatVectorTimeDerivative::MatVectorTimeDerivative(const InputParameters & parameters)
+  : VectorTimeDerivative(parameters), _coeff(getMaterialProperty<Real>("material"))
+{
+}
+
+Real
+MatVectorTimeDerivative::computeQpResidual()
+{
+  return _coeff[_qp] * VectorTimeDerivative::computeQpResidual();
+}
+
+Real
+MatVectorTimeDerivative::computeQpJacobian()
+{
+  return _coeff[_qp] * VectorTimeDerivative::computeQpJacobian();
+}


### PR DESCRIPTION
Instead of defining fixed material properties as coefficients in the kernels, use MOOSE materials. This allows for two-way coupling on the monoblock (transferring back temperature for temperature dependent sigma). This is only really needed for the JouleHeatingAuxKernel in this case, but I implemented some others for completeness.
This turns out to have very little effect on temperature, but is still useful to have.

The `AForm.i` input file is updated to use [Materials] block, which just uses simple constant parameters. This is because of the top secret parameterisations for electrical conductivity which cannot be seen by external eyes 👀. But the user may of course load their own parameterisation with a function.